### PR TITLE
Fix WordCounterSpliterator.tryAdvance

### DIFF
--- a/src/main/java/lambdasinaction/chap7/WordCount.java
+++ b/src/main/java/lambdasinaction/chap7/WordCount.java
@@ -83,8 +83,12 @@ public class WordCount {
 
         @Override
         public boolean tryAdvance(Consumer<? super Character> action) {
-            action.accept(string.charAt(currentChar++));
-            return currentChar < string.length();
+            if(currentChar < string.length()) {
+                action.accept(string.charAt(currentChar++));
+                return true;
+            } else {
+                return false;
+            }
         }
 
         @Override


### PR DESCRIPTION
fixes:
1. when initial string is empty, prevents throwing StringIndexOutOfBoundsException
2. the last valid iteration return true. old code returns false for the last character which breaks tryAdvance() specs