### PR TITLE
Using getResource()

### DIFF
--- a/src/main/java/lambdasinaction/chap3/ExecuteAround.java
+++ b/src/main/java/lambdasinaction/chap3/ExecuteAround.java
@@ -2,6 +2,8 @@ package lambdasinaction.chap3;
 
 import java.io.*;
 public class ExecuteAround {
+    private static final String FILENAME = ExecuteAround.class
+            .getResource("/lambdasinaction/chap3/data.txt").getPath();
 
 	public static void main(String ...args) throws IOException{
 
@@ -21,14 +23,14 @@ public class ExecuteAround {
 
     public static String processFileLimited() throws IOException {
         try (BufferedReader br =
-                     new BufferedReader(new FileReader("lambdasinaction/chap3/data.txt"))) {
+                     new BufferedReader(new FileReader(FILENAME))) {
             return br.readLine();
         }
     }
 
 
 	public static String processFile(BufferedReaderProcessor p) throws IOException {
-		try(BufferedReader br = new BufferedReader(new FileReader("lambdasinaction/chap3/data.txt"))){
+		try(BufferedReader br = new BufferedReader(new FileReader(FILENAME))){
 			return p.process(br);
 		}
 


### PR DESCRIPTION
In chapter 3, to let the ExecuteAround example run we need to convert the filename in a resource filename.

A simple way could be via a call to the getResource() method from Class and then converting the resulting URL to string by getPath().